### PR TITLE
Adds days iterator

### DIFF
--- a/isoweek.py
+++ b/isoweek.py
@@ -169,14 +169,14 @@ class Week(namedtuple('Week', ('year', 'week'))):
         if isinstance(other, (int, long, timedelta)):
             return self.__add__(-other)
         return self.toordinal() - other.toordinal()
-    
+
     def __iter__(self):
         """Defines the day iterator, starting at 0 -- the first day of
         the week."""
         self.__class__.n = 0
         self.__class__.iteration_ceiling = 6
         return self
-    
+
     def __next__(self):
         """Returns next iteration day of week using the day() method."""
         if self.__class__.n <= self.__class__.iteration_ceiling:
@@ -185,6 +185,12 @@ class Week(namedtuple('Week', ('year', 'week'))):
             return iteration_day
         else:
             raise StopIteration
+
+    def next(self):
+        """Python 2 compatibility for the __next__ method for
+        creating an iterator."""
+        return self.__class__.__next__()
+
 
 Week.min = Week(1,1)
 Week.max = Week(9999,52)

--- a/isoweek.py
+++ b/isoweek.py
@@ -189,7 +189,7 @@ class Week(namedtuple('Week', ('year', 'week'))):
     def next(self):
         """Python 2 compatibility for the __next__ method for
         creating an iterator."""
-        return self.__class__.__next__()
+        return self.__next__()
 
 
 Week.min = Week(1,1)

--- a/isoweek.py
+++ b/isoweek.py
@@ -169,6 +169,22 @@ class Week(namedtuple('Week', ('year', 'week'))):
         if isinstance(other, (int, long, timedelta)):
             return self.__add__(-other)
         return self.toordinal() - other.toordinal()
+    
+    def __iter__(self):
+        """Defines the day iterator, starting at 0 -- the first day of
+        the week."""
+        self.__class__.n = 0
+        self.__class__.iteration_ceiling = 6
+        return self
+    
+    def __next__(self):
+        """Returns next iteration day of week using the day() method."""
+        if self.__class__.n <= self.__class__.iteration_ceiling:
+            iteration_day = self.day(self.n)
+            self.__class__.n += 1
+            return iteration_day
+        else:
+            raise StopIteration
 
 Week.min = Week(1,1)
 Week.max = Week(9999,52)

--- a/test_isoweek.py
+++ b/test_isoweek.py
@@ -1,5 +1,6 @@
 import sys
 import unittest
+import datetime
 from isoweek import Week
 
 class TestWeek(unittest.TestCase):
@@ -144,6 +145,14 @@ class TestWeek(unittest.TestCase):
         next_week = w + 1
         self.assertEqual(str(next_week),   "2011W21")
         self.assertTrue(isinstance(next_week, MyWeek))
+    
+    def test_iterator(self):
+        w = Week(2011, 20)
+        for day in w:
+            self.assertIsInstance(day, datetime.date)
+        
+        for i, day in enumerate(w):
+            self.assertEqual(day, w.day(i))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Hi there @gisle, I really like this package! Thank you lots for putting in the work.

I've added a day iterator to the `Week()` class. I noticed myself not only iterating through the weeks of a year, but also through the days of a given week. So I decided to create an iterator for the `Week()` class that calls its `day(i)` method as a sequence from the first day (0) to the last day of the week (6). Here's how it should work:

```python
for day in Week(2016,1):
    print(type(day), day)
```
Output:
```
<class 'datetime.date'> 2016-01-04
<class 'datetime.date'> 2016-01-05
<class 'datetime.date'> 2016-01-06
<class 'datetime.date'> 2016-01-07
<class 'datetime.date'> 2016-01-08
<class 'datetime.date'> 2016-01-09
<class 'datetime.date'> 2016-01-10
```

I've added unit tests. Let me know what you think.